### PR TITLE
adds hidden files to initial repo

### DIFF
--- a/modules/github/main.tf
+++ b/modules/github/main.tf
@@ -55,7 +55,6 @@ resource "null_resource" "post_repo_creation" {
       git config user.email "nomail@dbt.com"
       git config user.name "Created by Terraform"
       git add */.*
-      git rm -f .cruft.json
       git commit -m "Initial commit from Terraform and cruft"
       git branch -M main
       git remote add origin ${local.https_url_with_pat}

--- a/modules/github/main.tf
+++ b/modules/github/main.tf
@@ -54,7 +54,7 @@ resource "null_resource" "post_repo_creation" {
       git init
       git config user.email "nomail@dbt.com"
       git config user.name "Created by Terraform"
-      git add */.*
+      git add * .*
       git commit -m "Initial commit from Terraform and cruft"
       git branch -M main
       git remote add origin ${local.https_url_with_pat}

--- a/modules/github/main.tf
+++ b/modules/github/main.tf
@@ -54,7 +54,8 @@ resource "null_resource" "post_repo_creation" {
       git init
       git config user.email "nomail@dbt.com"
       git config user.name "Created by Terraform"
-      git add *
+      git add */.*
+      git rm -f .cruft.json
       git commit -m "Initial commit from Terraform and cruft"
       git branch -M main
       git remote add origin ${local.https_url_with_pat}


### PR DESCRIPTION
The current script doesn't add:
```
.gitignore
.sqlfluff
.sqlfluffignore
```
into the new repo.
This command adds that, and makes sure the .cruft.json doesn't get included (since it is copied by the .* pattern)