### PR TITLE
improves cruft durability

### DIFF
--- a/modules/github/main.tf
+++ b/modules/github/main.tf
@@ -46,6 +46,7 @@ resource "null_resource" "post_repo_creation" {
       #!/bin/bash
       set -e
       # Clone the template and push it to the new repo
+      rm -rf cruft-template
       mkdir cruft-template
       cd cruft-template
       cruft create ${var.cruft_template_url} --extra-context '{"project_name": "${var.project_name}", "project_slug": "${var.project_slug}"}' --no-input
@@ -54,7 +55,8 @@ resource "null_resource" "post_repo_creation" {
       git init
       git config user.email "nomail@dbt.com"
       git config user.name "Created by Terraform"
-      git add * .*
+      git add *
+      git add .
       git commit -m "Initial commit from Terraform and cruft"
       git branch -M main
       git remote add origin ${local.https_url_with_pat}

--- a/modules/github/main.tf
+++ b/modules/github/main.tf
@@ -55,8 +55,7 @@ resource "null_resource" "post_repo_creation" {
       git init
       git config user.email "nomail@dbt.com"
       git config user.name "Created by Terraform"
-      git add *
-      git add .
+      git add -A
       git commit -m "Initial commit from Terraform and cruft"
       git branch -M main
       git remote add origin ${local.https_url_with_pat}


### PR DESCRIPTION
In testing the `post_repo_creation` script against bitbucket and other providers, I have found a more durable way to add "dotfiles", as well as recover from failed instances of `post_repo_creation`

I split `git add * .*` into:
`git add *`
`git add .`
While these can probably be one line, two lines works great and is easy to follow, not tempting folks to delete the space between * .

I also added `rm -tf cruft-template` right before the mkdir, to remove any existing directory that can remain in case it didn't get deleted in a previous run.  This solves a crashing error if mkdir doesn't work because it exists, and ensures that the directory is clean for a fresh copy of the results of cruft create.