### PR TITLE
Add Azure DevOps as a git provider

### DIFF
--- a/modules/azuredevops/README.md
+++ b/modules/azuredevops/README.md
@@ -1,0 +1,45 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_azuredevops"></a> [azuredevops](#requirement\_azuredevops) | >= 0.1.0 |
+| <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_github"></a> [azuredevops](#provider\_azuredevops) | >= 0.1.0 |
+| <a name="provider_null"></a> [null](#provider\_null) | >= 3.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [azuredevops_branch_policy_min_reviewers.dbt_repo](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/branch_policy_min_reviewers) | resource |
+| [azuredevops_git_repository.dbt_repo](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/git_repository) | resource |
+| [null_resource.post_repo_creation](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_cruft_template_url"></a> [cruft\_template\_url](#input\_cruft\_template\_url) | URL for the Cruft template | `string` | n/a | yes |
+| <a name="input_devops_token"></a> [devops\_token](#input\_azuredevops\_token) | DevOps token to create repos | `string` | n/a | yes |
+| <a name="input_devops_url"></a> [devops\_url](#input\_azuredevops\_url) | DevOps organization URL | `string` | n/a | yes |
+| <a name="input_devops_project_id"></a> [devops\_project_id](#input\_azuredevops\_project_id) | DevOps Project ID | `string` | n/a | yes |
+| <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Project Name | `string` | n/a | yes |
+| <a name="input_project_slug"></a> [project\_slug](#input\_project\_slug) | Slug for the project | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_devops_repo_remote_url"></a> [devops\_repo\_remote\_url](#output\_azuredevops\_repo\_remote\_url) | HTTPS URL for the created repository |
+<!-- END_TF_DOCS -->

--- a/modules/azuredevops/main.tf
+++ b/modules/azuredevops/main.tf
@@ -1,0 +1,83 @@
+terraform {
+  required_version = ">= 1.3"
+
+  required_providers {
+    azuredevops = {
+      source  = "microsoft/azuredevops"
+      version = ">= 0.1.0"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = ">= 3.0"
+    }
+  }
+}
+
+provider "azuredevops" {
+  org_service_url       = var.devops_url
+  personal_access_token = var.devops_token
+}
+
+resource "azuredevops_git_repository" "dbt_repo" {
+  project_id = var.devops_project_id
+  name       = "dbt_${var.project_slug}"
+  initialization {
+    init_type = "Clean"
+  }
+}
+
+resource "azuredevops_branch_policy_min_reviewers" "dbt_repo" {
+  project_id = var.devops_project_id
+  enabled    = true
+  blocking   = true
+
+  settings {
+    reviewer_count                         = 1
+    submitter_can_vote                     = false
+    last_pusher_cannot_approve             = true
+    allow_completion_with_rejects_or_waits = false
+    on_push_reset_approved_votes           = true
+    on_last_iteration_require_vote         = false
+
+    scope {
+      repository_id  = azuredevops_git_repository.dbt_repo.id
+      repository_ref = azuredevops_git_repository.dbt_repo.default_branch
+      match_type     = "Exact"
+    }
+  }
+}
+
+locals {
+  repo_url           = azuredevops_git_repository.project_repository.remote_url
+  https_url_with_pat = replace(local.repo_url, "https://", "https://${var.devops_token}@")
+}
+
+resource "null_resource" "post_repo_creation" {
+  provisioner "local-exec" {
+    command = <<-EOT
+      #!/bin/bash
+      set -e
+      # Clone the template and push it to the new repo
+      rm -rf cruft-template
+      mkdir cruft-template
+      cd cruft-template
+      cruft create ${var.cruft_template_url} --extra-context '{"project_name": "${var.project_name}", "project_slug": "${var.project_slug}"}' --no-input
+      cd ${var.project_slug}
+      git config --global init.defaultBranch main
+      git init
+      git config user.email "nomail@dbt.com"
+      git config user.name "Created by Terraform"
+      git add -A
+      git commit -m "Initial commit from Terraform and cruft"
+      git branch -M main
+      git remote add origin ${local.https_url_with_pat}
+      git push -u origin main
+      cd ../..
+      rm -rf cruft-template
+      EOT
+
+    environment = {
+      TOKEN = var.devops_token
+    }
+  }
+}

--- a/modules/azuredevops/main.tf
+++ b/modules/azuredevops/main.tf
@@ -22,7 +22,7 @@ resource "azuredevops_git_repository" "dbt_repo" {
   project_id = var.devops_project_id
   name       = "dbt_${var.project_slug}"
   initialization {
-    init_type = "Clean"
+    init_type = "Uninitialized"
   }
 }
 

--- a/modules/azuredevops/outputs.tf
+++ b/modules/azuredevops/outputs.tf
@@ -1,0 +1,3 @@
+output "devops_repo_remote_url" {
+  value = azuredevops_git_repository.project_repository.remote_url
+}

--- a/modules/azuredevops/variables.tf
+++ b/modules/azuredevops/variables.tf
@@ -1,5 +1,15 @@
-variable "github_token" {
-  description = "GitHub token to create repos"
+variable "devops_token" {
+  description = "Azure DevOps PAT"
+  type        = string
+}
+
+variable "devops_url" {
+  description = "Azure DevOps Organization URL"
+  type        = string
+}
+
+variable "devops_project_id" {
+  description = "Azure DevOps Project ID"
   type        = string
 }
 


### PR DESCRIPTION
Hi @b-per, I saw your talk at Coalesce (great job by the way!) and was motivated to start using Terraform for our projects. Here I added Azure DevOps as a possible git provider and tried to mirror your setup for Github as much as possible. I need to test the "post_repo_creation" resource in a DevOps pipeline to make sure that it works fine there instead of in Actions and I hope to do that today. Once I test it I can add an example pipeline as well. 

I also fixed a minor typo in the Github variables.

I'd be keen to contribute also a Databricks module, but that will take me a bit! 

Needless to say I'm new to Terraform, so any feedback is welcome!